### PR TITLE
Don't enable assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,21 +121,7 @@ sourceSets {
     }
 }
 
-def jvmTestFlags = ['-ea']
-
 idea {
-    workspace {
-        iws.withXml { xmlFile ->
-            def runManager = xmlFile.asNode().component.find { it.@name == 'RunManager' }
-
-            // enable assertions for junit tests
-            def junitDefaults = runManager.configuration.find { it.@default == 'true' && it.@type == 'JUnit' }
-            junitDefaults.option.find { it.@name == 'VM_PARAMETERS' }.replaceNode {
-                option(name: 'VM_PARAMETERS', value: jvmTestFlags.join(' '))
-            }
-        }
-    }
-
     project {
         languageLevel = 'JDK_1_8' // \o/
         vcs = 'Git'


### PR DESCRIPTION
In order to workaround an issue in the CrateClient from current master.

Besides, for stress tests we don't want to execute assertions anyway.