### PR TITLE
added script that fetches commit date from github

### DIFF
--- a/api/schema.sql
+++ b/api/schema.sql
@@ -1,8 +1,8 @@
-CREATE TABLE IF NOT EXISTS "benchmark"."history" (
+CREATE TABLE IF NOT EXISTS "doc"."benchmarks" (
     version_info OBJECT (STRICT) AS (
         number STRING,
         hash STRING,
-        timestamp TIMESTAMP
+        date TIMESTAMP
     ),
     statement STRING,
     started TIMESTAMP,
@@ -25,12 +25,9 @@ CREATE TABLE IF NOT EXISTS "benchmark"."history" (
         n INTEGER,
         variance DOUBLE,
         stdev DOUBLE,
-        hist ARRAY(OBJECT (STRICT) AS (
-            bin DOUBLE,
-            num INTEGER
-        ))
+        samples ARRAY(DOUBLE)
     )
-) CLUSTERED INTO 8 SHARDS WITH (
-    number_of_replicas = '1-3',
+) CLUSTERED INTO 6 SHARDS WITH (
+    number_of_replicas = '0-2',
     column_policy = 'strict'
 );

--- a/api/setup.py
+++ b/api/setup.py
@@ -21,7 +21,8 @@ setup(
     namespace_packages=['crate'],
     entry_points={
         'console_scripts': [
-            'app = crate.benchapi.cli:run'
+            'app = crate.benchapi.cli:run',
+            'bench = crate.benchapi.scripts:main',
         ]
     }
 )

--- a/api/src/crate/benchapi/application.py
+++ b/api/src/crate/benchapi/application.py
@@ -47,7 +47,7 @@ class CrateResource(Resource):
 
 class Result(CrateResource):
     """
-    Resource for benchmark.history
+    Resource for doc.benchmarks
     Supported method: GET
     """
 
@@ -96,7 +96,7 @@ class Result(CrateResource):
                            runtime_stats['stdev'] as "stdev",
                            runtime_stats['variance'] as "variance",
                            statement
-                    FROM "benchmark"."history"
+                    FROM "doc"."benchmarks"
                     {}
                     ORDER BY version, statement
                     """.format(" ".join(where_clause))

--- a/api/src/crate/benchapi/scripts.py
+++ b/api/src/crate/benchapi/scripts.py
@@ -1,0 +1,52 @@
+# vi: set fileencoding=utf-8
+# -*- coding: utf-8; -*-
+
+import toml
+import json
+import argparse
+import contextlib
+from datetime import datetime
+from urllib.request import urlopen
+from crate.client import connect
+
+
+def update_commit_date(cursor, row):
+    url = 'https://api.github.com/repos/crate/crate/commits/' + row[0]
+    with contextlib.closing(urlopen(url)) as resp:
+        data = json.loads(resp.read().decode('utf-8'))
+        date_str = data['commit']['author']['date']
+        assert date_str
+        commit_date = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ').date()
+        print('Updating hash {} with date {}'.format(row[0], commit_date))
+        cursor.execute('''
+            UPDATE benchmarks
+            SET version_info['date'] = ?
+            WHERE version_info['hash'] = ?
+        ''', (commit_date, row[0], ))
+
+
+def add_timestamp(ns, config={}):
+    with connect(config.get('crate_hosts')) as conn:
+        cur = conn.cursor()
+        cur.execute('''
+            SELECT distinct(version_info['hash']) as hash
+            FROM benchmarks
+            WHERE version_info['date'] IS NULL
+        ''')
+        for row in cur.fetchall():
+            update_commit_date(cur, row)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--conf',
+                        help='Path to config.toml',
+                        type=argparse.FileType('r'), required=True)
+    subparsers = parser.add_subparsers()
+
+    parser_add_ts = subparsers.add_parser('add-timestamp')
+    parser_add_ts.set_defaults(func=add_timestamp)
+
+    args = parser.parse_args()
+    config = toml.loads(args.conf.read())
+    args.func(args, config)


### PR DESCRIPTION
this script needs to be run after the benchmark run in order to update
the version_info column with the commit date of the crate version

this is required for the benchmark api to order by timestamp

@bogensberger can you take a look please