### PR TITLE
do not close connection when resource is deleted

### DIFF
--- a/api/src/crate/benchapi/application.py
+++ b/api/src/crate/benchapi/application.py
@@ -25,7 +25,6 @@ class CrateResource(Resource):
 
     def __del__(self):
         self.cursor.close()
-        self.connection.close()
 
     @property
     def connection(self):


### PR DESCRIPTION
since the connection is an app global, it must not be closed when the resource is deleted