### PR TITLE
Increase iterations for ordered cross join

### DIFF
--- a/py/specs/joins.toml
+++ b/py/specs/joins.toml
@@ -13,7 +13,7 @@ iterations = 50
 [[queries]]
 # QAF
 statement = "select articles.name as article, colors.name as color from articles, colors order by article, color limit 10000"
-iterations = 50
+iterations = 2560
 
 [[queries]]
 # QTF


### PR DESCRIPTION
Increases the iterations from 50 to 2560 because with only 50 iterations
the result against the same CrateDB version deviated between by up to
15%